### PR TITLE
Refactoring of ODB/SQL generation

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -64,6 +64,8 @@ set(ODBFLAGS
   --schema-format sql
   --sql-file-suffix -odb
   --pgsql-server-version 9.1
+  --include-prefix model/
+  --include-with-brackets
   --default-pointer "std::shared_ptr")
 
 set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -pedantic\

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,9 +1,3 @@
-include_directories(
-  include)
-
-include_directories(SYSTEM
-  ${ODB_INCLUDE_DIRS})
-
 set(ODB_SOURCES
   include/model/buildaction.h
   include/model/buildlog.h
@@ -18,4 +12,4 @@ generate_odb_files("${ODB_SOURCES}")
 
 add_odb_library(model ${ODB_CXX_SOURCES})
 
-install_sql(${CMAKE_CURRENT_BINARY_DIR})
+install_sql()

--- a/plugins/cpp/model/CMakeLists.txt
+++ b/plugins/cpp/model/CMakeLists.txt
@@ -18,7 +18,7 @@ set(ODB_SOURCES
 
 generate_odb_files("${ODB_SOURCES}")
 
-add_odb_library_plugin(cppmodel ${PLUGIN_NAME} ${ODB_CXX_SOURCES})
+add_odb_library(cppmodel ${ODB_CXX_SOURCES})
 target_link_libraries(cppmodel model)
 
-install_sql(${CMAKE_CURRENT_BINARY_DIR})
+install_sql()

--- a/plugins/metrics/model/CMakeLists.txt
+++ b/plugins/metrics/model/CMakeLists.txt
@@ -1,13 +1,9 @@
-include_directories(  
-  include
-  ${PROJECT_SOURCE_DIR}/model/include)
-
 set(ODB_SOURCES
   include/model/metrics.h)
 
 generate_odb_files("${ODB_SOURCES}")
 
-add_odb_library_plugin(metricsmodel ${PLUGIN_NAME} ${ODB_CXX_SOURCES})
+add_odb_library(metricsmodel ${ODB_CXX_SOURCES})
 add_dependencies(metricsmodel model)
 
-install_sql(${CMAKE_CURRENT_BINARY_DIR})
+install_sql()

--- a/plugins/search/parser/CMakeLists.txt
+++ b/plugins/search/parser/CMakeLists.txt
@@ -1,10 +1,9 @@
 include_directories(
   include
   ${PROJECT_SOURCE_DIR}/model/include
-  ${PROJECT_SOURCE_DIR}/model/include/model
   ${PROJECT_SOURCE_DIR}/util/include
   ${PROJECT_SOURCE_DIR}/parser/include
-  ${PROJECT_BINARY_DIR}
+  ${CMAKE_BINARY_DIR}/model/include
   ${PLUGIN_DIR}/indexer/gen-cpp
   ${PLUGIN_DIR}/indexer/include)
 


### PR DESCRIPTION
The ODB generated files are placed under a model/include directory
under the current binary directory, except for the .cxx files. This
way the plugin creators don't have to use a special CMake function
for determining their location, because this structure will be common
for all models.
The plugin creators should'n be aware of the structure of the binary
directory.